### PR TITLE
Bindings for the name attribute of controls

### DIFF
--- a/dist/ember_forms.js
+++ b/dist/ember_forms.js
@@ -51,7 +51,8 @@ Ember.Forms.ControlMixin = Ember.Mixin.create({
   },
   hasValue: (function() {
     return this.get('value') !== null;
-  }).property('value').readOnly()
+  }).property('value').readOnly(),
+  name: Em.computed.alias('parentView.name')
 });
 
 
@@ -79,6 +80,7 @@ Em.Forms.HasPropertyMixin = Em.Mixin.create({
       return Em.assert(false, 'Property could not be found.');
     }
   }).property('parentView.property'),
+  name: Em.computed.defaultTo('propertyName'),
   init: function() {
     this._super();
     return Em.Binding.from('model.errors.' + this.get('propertyName')).to('errors').connect(this);
@@ -850,6 +852,7 @@ Em.Forms.FormCheckboxComponent = Em.Forms.FormGroupComponent.extend({
     "class": false,
     model: Em.computed.alias('parentView.parentView.model'),
     propertyName: Em.computed.alias('parentView.parentView.propertyName'),
+    name: Em.computed.alias('parentView.parentView.name'),
     init: function() {
       this._super();
       return Ember.Binding.from("model." + (this.get('propertyName'))).to('checked').connect(this);

--- a/src/control_mixin.coffee
+++ b/src/control_mixin.coffee
@@ -12,3 +12,5 @@ Ember.Forms.ControlMixin = Ember.Mixin.create
     hasValue: (->
         @get('value') isnt null
     ).property('value').readOnly()
+
+    name: Em.computed.alias 'parentView.name'

--- a/src/form_checkbox.coffee
+++ b/src/form_checkbox.coffee
@@ -12,6 +12,7 @@ Em.Forms.FormCheckboxComponent = Em.Forms.FormGroupComponent.extend(
         class: no
         model: Em.computed.alias 'parentView.parentView.model'
         propertyName: Em.computed.alias 'parentView.parentView.propertyName'
+        name: Em.computed.alias 'parentView.parentView.name'
         init: ->
             @_super()
             Ember.Binding.from("model.#{@get('propertyName')}").to('checked').connect(@)

--- a/src/has_property_mixin.coffee
+++ b/src/has_property_mixin.coffee
@@ -19,6 +19,8 @@ Em.Forms.HasPropertyMixin = Em.Mixin.create
             Em.assert false, 'Property could not be found.'
     ).property('parentView.property')
 
+    name: Em.computed.defaultTo 'propertyName'
+
     init: ->
         @_super()
         Em.Binding.from('model.errors.' + @get('propertyName')).to('errors').connect(this)


### PR DESCRIPTION
I find it useful to be able to set the name attribute of the control elements, for example to find the controls within integration tests. Standard ember input helper allow this, see http://emberjs.com/guides/templates/input-helpers/, but not ember-forms. Added the name property of the controls as a computed property, defaults to propertyName, so you have some reasonable defaults.

Hope this might be helpful to others!

Greetings,
Simon
