### PR TITLE
Add main element to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,18 +7,18 @@
     "Asaf Shakarchi <asaf000@gmail.com>"
   ],
   "keywords": [
-      "ember",
-      "emberjs",
-      "bootstap",
-      "twitter-bootstrap",
-      "forms",
-      "coffee",
-      "ui",
-      "html",
-      "js",
-      "javascript",
-      "css3",
-      "css"
+    "ember",
+    "emberjs",
+    "bootstap",
+    "twitter-bootstrap",
+    "forms",
+    "coffee",
+    "ui",
+    "html",
+    "js",
+    "javascript",
+    "css3",
+    "css"
   ],
   "ignore": [
     "**/.*",
@@ -37,7 +37,10 @@
     "package.json",
     "node_modules",
     "src",
-    "test"
+    "test",
+    "bower_components",
+    "vendor",
+    "tests"
   ],
   "license": "Apache2",
   "devDependencies": {
@@ -49,5 +52,6 @@
     "ember-qunit": "~0.1.8",
     "ember-model": "~0.0.11",
     "qunit": "~1.14.0"
-  }
+  },
+  "main": "./dist/globals/main.js"
 }


### PR DESCRIPTION
It's very helpful with tools like Brunch, and others, to have a main entry point defined.
People can easily override this if they prefer another flavor, such as amd, etc.
