### PR TITLE
adding support for Ember-Data style errors

### DIFF
--- a/addon/control_help.js
+++ b/addon/control_help.js
@@ -28,7 +28,7 @@ export default Em.Component.extend(InFormMixin, {
     return Em.Binding.from('model.errors.' + this.get('parentView.propertyName')).to('errors').connect(this);
   },
   helpText: (function() {
-    return this.get('errors.firstObject') || this.get('text');
+    return this.get('errors.firstObject.message') || this.get('errors.firstObject') || this.get('text');
   }).property('text', 'errors.firstObject'),
   hasHelp: (function() {
     var _ref;


### PR DESCRIPTION
Hey @asaf,

Migrating to ember-data and ember-cli on my project and noticed that the errors were not displaying properly. I was seeing `[object object]` in my templates instead of the actual error text.

I'm not sure if this is a new thing, but it looks like the `DS.Errors` array now has an object for each field error instead of plain text. Assuming we have a post that has a validation error on the title, it would look like this:

```js
// Assuming we've tried to save the record and our server returned an error on the title...
var post = this.get('currentModel');
post.get('errors.title')
=> [{message: 'Title cannot be blank', attribute: 'title'}]
```

This small change appears to fix the problem.