### PR TITLE
add show errors on submit

### DIFF
--- a/addon/form.js
+++ b/addon/form.js
@@ -46,11 +46,12 @@ export default Em.Component.extend({
 
   /*
   Form submit
-  
+
   Optionally execute model validations and perform a form submission.
    */
   submit: function(e) {
     var promise;
+    var self = this;
     if (e) {
       e.preventDefault();
     }
@@ -64,7 +65,21 @@ export default Em.Component.extend({
             return _this.get('targetObject').send(_this.get('action'));
           }
         };
+      })(this)).catch((function(_this) {
+      // if the form don't valdiate.
+      // show errors on all fields.
+        self.showErrors(_this);
       })(this));
     }
+  }
+  // show errors on all child fields.
+  showErrors: function (view) {
+    var self = this;
+    jQuery.each(view._childViews, function (key, validation) {
+      validation.set('canShowErrors', true);
+      if (validation._childViews) {
+        self.showErrors(validation);
+      }
+    });
   }
 });


### PR DESCRIPTION
sets "canShowErrors" attribute to true on all fields if validation fails. not sure if you want to add this feature but it seems like a pretty common case.

it also does this recursively because that seems like the best way to handle forms with relationships (or forms within forms)
