### PR TITLE
propertyIsModel attribute added for em-select

### DIFF
--- a/addon/mixins/control.js
+++ b/addon/mixins/control.js
@@ -8,7 +8,14 @@ export default Em.Mixin.create({
   "class": 'form-control',
   init: function() {
     this._super();
-    return Em.Binding.from("model." + (this.get('propertyName'))).to('value').connect(this);
+
+    var propertyIsModel = this.get('parentView.propertyIsModel');
+    if(propertyIsModel) {
+    	return Em.Binding.from("model" + '.' + (this.get('propertyName')) + '.content').to('selection').connect(this); 
+    } else {
+    	return Em.Binding.from("model" + '.' + (this.get('propertyName'))).to('value').connect(this);    	
+    }
+    
   },
   hasValue: (function() {
     return this.get('value') !== null;

--- a/addon/select.js
+++ b/addon/select.js
@@ -11,6 +11,9 @@ Syntax:
     optionValuePath=keyForValue
     optionLabelPath=keyForLabel
     prompt="Optional default prompt"}}
+    
+    //Optional params
+    @param propertyIsModel - (boolean) forces the selected object to be assigned to the property instead of the optionValuePath 
  */
 export default FormGroupComponent.extend({
   v_icons: false,
@@ -22,6 +25,7 @@ export default FormGroupComponent.extend({
     optionLabelPath: Em.computed.alias('parentView.optionLabelPath'),
     prompt: Em.computed.alias('parentView.prompt')
   }),
+  propertyIsModel:false,
   property: void 0,
   content: void 0,
   optionValuePath: void 0,


### PR DESCRIPTION
#73 #72 

new attribute for `{{em-select}}` 

- propertyIsModel : will bind to the model in the collection instead of the value.

```javascript
            {{em-select
            label="Employee"
            property="employee"
            propertyIsModel=true
            content=employees
            optionValuePath="content.id"
            optionLabelPath="content.name"
            disabled=false
            prompt="Please Select"
            }}
```

Now the employee object will bind to the actual employee model not the id.
