### PR TITLE
Icons don't display properly in horizontal forms

### DIFF
--- a/app/templates/components/formgroup/form-group-control.hbs
+++ b/app/templates/components/formgroup/form-group-control.hbs
@@ -1,7 +1,13 @@
 {{#if controlWrapper}}
     <div {{bind-attr class=controlWrapper}}>
         {{view controlView viewName=controlViewName property=propertyName id=cid}}
+        {{#if v_icons}}
+            <span class="form-control-feedback"><i {{bind-attr class=v_icon}}></i></span>
+        {{/if}}
     </div>
 {{else}}
     {{view controlView viewName=controlViewName property=propertyName id=cid}}
+    {{#if v_icons}}
+        <span class="form-control-feedback"><i {{bind-attr class=v_icon}}></i></span>
+    {{/if}}
 {{/if}}

--- a/app/templates/components/formgroup/form-group.hbs
+++ b/app/templates/components/formgroup/form-group.hbs
@@ -23,10 +23,6 @@
         {{partial 'components/formgroup/form-group-control'}}
     {{/if}}
 
-    {{#if v_icons}}
-        <span class="form-control-feedback"><i {{bind-attr class=v_icon}}></i></span>
-    {{/if}}
-
     {{!Currently no errors when layout is inline}}
     {{#unless form.isInline}}
         {{#if canShowErrors}}


### PR DESCRIPTION
As I understand it, the success/failure icons should be in this form:

``` html
<div class="col-sm-10">
  <input class="form-control" placeholder="Username">
  <span class="form-control-feedback"><i class="fa fa-check"></i></span>
</div>
```

When using horizontal forms in this library, this is the result:

``` html
<div class="col-sm-10">
  <input class="form-control" placeholder="Username">
</div>
<span class="form-control-feedback"><i class="fa fa-check"></i></span>
```

Which causes the icon to be displayed underneath the form control rather than inside of it.
