### PR TITLE
add note to use ember-rapid-forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ With Ember-CLI:
 ```
 npm install --save-dev ember-idx-forms
 ```
+When you need support for ember version >= 2.0 please use https://github.com/piceaTech/ember-rapid-forms
 
 Please visit the documentation for installation & usage documentations: http://indexiatech.github.io/ember-forms
 


### PR DESCRIPTION
Hey,
to make it more clear that this addon does not support ember > 1.13

regards #105 
